### PR TITLE
Adding ability to change subject with new Action type 'subject'

### DIFF
--- a/brutal/core/models.py
+++ b/brutal/core/models.py
@@ -182,6 +182,7 @@ class Action(object):
 
     action types:
         msg
+        subject
         join
         part
     """
@@ -268,6 +269,18 @@ class Action(object):
             self.destination_room = room
 
         self.action_type = 'message'
+        if msg is not None:
+            self._add_to_meta('body', msg)
+        return self
+
+    def subject(self, msg, room=None):
+        """
+        send a msg to a room
+        """
+        if room:
+            self.destination_room = room
+
+        self.action_type = 'subject'
         if msg is not None:
             self._add_to_meta('body', msg)
         return self

--- a/brutal/core/plugin.py
+++ b/brutal/core/plugin.py
@@ -555,6 +555,10 @@ class BotPlugin(object):
         a = Action(source_bot=self.bot, source_event=event).msg(msg, room=room)
         self._queue_action(a, event)
 
+    def subject(self, msg, room=None, event=None):
+        a = Action(source_bot=self.bot, source_event=event).subject(msg, room=room)
+        self._queue_action(a, event)
+
     # internal
 
     def enable(self):

--- a/brutal/protocols/xmpp.py
+++ b/brutal/protocols/xmpp.py
@@ -182,3 +182,13 @@ class XmppBackend(ProtocolBackend):
                             room_jid = jid.internJID(room)
                             message = muc.GroupChat(recipient=room_jid, body=body)
                             self.client.send(message.toElement())
+        if action.action_type == 'subject':
+            new_subject = action.meta.get('body')
+            if new_subject:
+                if action.destination_rooms:
+                    for room in action.destination_rooms:
+                        if action.scope == 'public':
+                            # TODO: replace this with an actual room lookup of known rooms
+                            room_jid = jid.internJID(room)
+                            message = muc.GroupChat(recipient=room_jid, subject=new_subject)
+                            self.client.send(message.toElement())


### PR DESCRIPTION
The goal is to allow plugin developers a way to easily set the subject of a room using a bot.

The implementation from inside a BotPlugin object is:
self.subject(topic, event=event)

The usage and code is nearly identical to the message action type.
