### PR TITLE
fixed irc messages sending

### DIFF
--- a/brutal/protocols/irc.py
+++ b/brutal/protocols/irc.py
@@ -402,12 +402,12 @@ class SimpleIrcBotProtocol(irc.IRCClient):
         if action.action_type == 'message':
             body = action.meta.get('body')
             if body:
-                dest = action.destination_room
-                if dest:
-                    if dest[0] == '#':
-                        self.say(dest, body)
-                    else:
-                        self.msg(dest, body)
+                for dest in action.destination_rooms:
+                    if dest:
+                        if dest[0] == '#':
+                            self.say(dest, body)
+                        else:
+                            self.msg(dest, body)
 
 
 class IrcBotClient(protocol.ReconnectingClientFactory):


### PR DESCRIPTION
I am not sure if I did something wrong but without this fix and while running the example bot I usually got an exception saying that `action.destination_room` doesn't exist.

This fixed it, though I am not sure if it didn't break something else.
