### PR TITLE
IRC rooms in config should start with #

### DIFF
--- a/brutal/spawn/spawn_template/spawn_name/config.py
+++ b/brutal/spawn/spawn_template/spawn_name/config.py
@@ -27,7 +27,7 @@ BOTS = [
             #     'port': 6667,
             #     'use_ssl': False, # default or irc
             #     'password': '',
-            #     'channels': ['room', ('private_room', 'pass')]
+            #     'channels': ['#room', ('#private_room', 'pass')]
             # }
         ],
         'enabled_plugins': {
@@ -45,7 +45,7 @@ BOTS = [
     #             'port': 6667,
     #             'use_ssl': False, # default or irc
     #             'password': '',
-    #             'channels': ['room', ('private_room', 'pass')]
+    #             'channels': ['#room', ('#private_room', 'pass')]
     #         }
     #     ],
     #     'plugin_settings': {}


### PR DESCRIPTION
It took me a while to realize this.

If they don't it can have undesired side effects (the whole delay_task
and loop_task mechanism will stop working and your log size will
increase dramatically).
